### PR TITLE
Fix ports in config: Cast string to int

### DIFF
--- a/broti/cmdline.py
+++ b/broti/cmdline.py
@@ -28,8 +28,7 @@ def start_bot(argv):
 
     for section in config.sections():
         host, _, port = section.partition(':')
-        if not port:
-            port = 6667
+        port = int(port) if port else 6667
 
         bot = Bot(host, port, dict(config.items(section)))
         bot.start()


### PR DESCRIPTION
```
File "/home/user/.local/lib/python3.6/site-packages/irc/connection.py", line 49, in connect
    sock.connect(server_address)
TypeError: an integer is required (got type str)
```